### PR TITLE
Allow creating nested reportPath

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -20,7 +20,7 @@ module.exports = (results) => {
     const report = xml(testExecutions(results), {declaration: true, indent: xmlIndent(config.indent)});
 
     if (!fs.existsSync(config.reportPath)) {
-        fs.mkdirSync(config.reportPath);
+        fs.mkdirSync(config.reportPath, { recursive: true });
     }
 
     const reportFile = path.join(config.reportPath, config.reportFile);


### PR DESCRIPTION
If the reportPath does not exist, create it and any non-existing parent folders, by passing a configuration option to `fs.mkdir`.