### PR TITLE
Upgrade jest libraries to avoid bracets and mem packages vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "jest": "^22.4.3",
+    "jest": "^25.1.0",
     "xml": "^1.0.1"
   },
   "jest": {


### PR DESCRIPTION
This pull request updates the jest library that it uses for it's own test purpose.
A future work suggestion would be to move it as a devDependencies, since it's not used in the wrapper at all.